### PR TITLE
Fix upload section adding deleted images to the canvas

### DIFF
--- a/src/sections/upload-section.js
+++ b/src/sections/upload-section.js
@@ -129,7 +129,10 @@ export const UploadPanel = observer(({ store }) => {
         isLoading={isLoading}
         getCredit={(image) => (
           <div>
-            <Button icon="trash" onClick={() => handleDelete(image)}></Button>
+            <Button icon="trash" onClick={(e) => {
+              e.stopPropagation();
+              handleDelete(image);
+            }}></Button>
           </div>
         )}
         onSelect={async (item, pos, element) => {


### PR DESCRIPTION
## Update:
Updated this solution to use event.stopPropagation.

## Issue: 
upload-section adds an image to the canvas when deleting.

## Expected:
Image should be deleted and no image added to the canvas.

## Steps to reproduce:

Uncommenting the following line in App.js:
`DEFAULT_SECTIONS.unshift(UploadSection);`

add `import {UploadSection} from './sections/upload-section'` to the top of App.js

## Video of issue: (deleted image is added to the canvas)
https://github.com/user-attachments/assets/18c56f07-819f-4d3f-96bf-9b6109ceb4de

## Video with solution: (deleted image does not get added to the canvas)
https://github.com/user-attachments/assets/8722409a-98d0-4b32-aa6c-85765e048a06

Cheers, 
Michael Dimmitt